### PR TITLE
Add Flask API for equations and DB export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# AFreshStart
+# REST API for Equation Evaluation
+
+This project provides a simple REST API that retrieves input variables from a Google Sheet, evaluates stored mathematical equations, and exports the results to a SQL database such as Snowflake.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Create a `.env` file with the required credentials for Google Sheets and your SQL database. Example variables:
+   - `GOOGLE_SHEET_KEY`
+   - `GOOGLE_SERVICE_ACCOUNT_FILE`
+   - `DATABASE_URL` (SQLAlchemy connection string)
+
+3. Run the API:
+   ```bash
+   python -m app.main
+   ```
+
+## Endpoints
+
+- `POST /equations` – Add a new equation.
+- `GET /equations` – List stored equations.
+- `POST /run` – Retrieve variables from the Google Sheet, evaluate equations, and export results to the database.
+
+Stored equations are simple Python expressions that operate on variables from the Google Sheet. For example:
+
+```json
+{"name": "total", "expression": "a + b * c"}
+```
+
+## Notes
+
+- Use the Google Sheet's first row as variable names.
+- Supported databases depend on the SQLAlchemy driver specified in `DATABASE_URL`.
+- Snowflake is recommended for production, but any SQLAlchemy-compatible database can be used for testing.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# Package initializer

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,29 @@
+import os
+from sqlalchemy import create_engine, MetaData, Table, Column, Integer, String, Text
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///local.db")
+engine = create_engine(DATABASE_URL)
+Session = sessionmaker(bind=engine)
+metadata = MetaData()
+
+# Table to store equations
+Equations = Table(
+    "equations",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("name", String(50), nullable=False),
+    Column("expression", Text, nullable=False),
+)
+
+# Table to store results
+Results = Table(
+    "results",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("equation", String(50)),
+    Column("result", String(100)),
+)
+
+def init_db():
+    metadata.create_all(engine)

--- a/app/equations.py
+++ b/app/equations.py
@@ -1,0 +1,17 @@
+from typing import List
+from sqlalchemy.orm import Session
+
+from .database import Equations
+
+
+def add_equation(session: Session, name: str, expression: str) -> int:
+    ins = Equations.insert().values(name=name, expression=expression)
+    result = session.execute(ins)
+    session.commit()
+    return result.inserted_primary_key[0]
+
+
+def list_equations(session: Session) -> List[dict]:
+    sel = Equations.select()
+    rows = session.execute(sel).fetchall()
+    return [{"id": r.id, "name": r.name, "expression": r.expression} for r in rows]

--- a/app/google_sheet.py
+++ b/app/google_sheet.py
@@ -1,0 +1,20 @@
+import os
+import pandas as pd
+import gspread
+from oauth2client.service_account import ServiceAccountCredentials
+
+
+SCOPES = ["https://spreadsheets.google.com/feeds", "https://www.googleapis.com/auth/drive"]
+
+SHEET_KEY = os.getenv("GOOGLE_SHEET_KEY")
+SERVICE_ACCOUNT_FILE = os.getenv("GOOGLE_SERVICE_ACCOUNT_FILE")
+
+
+def get_sheet_data() -> pd.DataFrame:
+    creds = ServiceAccountCredentials.from_json_keyfile_name(
+        SERVICE_ACCOUNT_FILE, SCOPES
+    )
+    client = gspread.authorize(creds)
+    sheet = client.open_by_key(SHEET_KEY).sheet1
+    data = sheet.get_all_records()
+    return pd.DataFrame(data)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,52 @@
+import json
+from flask import Flask, request, jsonify
+from sqlalchemy.orm import Session
+
+from .database import init_db, Session as DBSession, Results
+from .google_sheet import get_sheet_data
+from .equations import add_equation, list_equations
+
+app = Flask(__name__)
+init_db()
+
+
+@app.route("/equations", methods=["POST"])
+def create_equation():
+    data = request.get_json()
+    name = data.get("name")
+    expression = data.get("expression")
+    if not name or not expression:
+        return jsonify({"error": "name and expression required"}), 400
+    with DBSession() as session:
+        eq_id = add_equation(session, name, expression)
+    return jsonify({"id": eq_id, "name": name, "expression": expression})
+
+
+@app.route("/equations", methods=["GET"])
+def get_equations():
+    with DBSession() as session:
+        equations = list_equations(session)
+    return jsonify(equations)
+
+
+@app.route("/run", methods=["POST"])
+def run_equations():
+    df = get_sheet_data()
+    variables = df.iloc[0].to_dict()
+    with DBSession() as session:
+        eqs = list_equations(session)
+        results = []
+        for eq in eqs:
+            try:
+                result_value = eval(eq["expression"], {}, variables)
+            except Exception as exc:
+                result_value = str(exc)
+            ins = Results.insert().values(equation=eq["name"], result=str(result_value))
+            session.execute(ins)
+            results.append({"equation": eq["name"], "result": result_value})
+        session.commit()
+    return jsonify(results)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+Flask
+pandas
+SQLAlchemy
+snowflake-connector-python[gcp]>=2.7.9
+snowflake-sqlalchemy
+psycopg2-binary
+openpyxl
+gspread
+oauth2client


### PR DESCRIPTION
## Summary
- add `.gitignore` and `requirements.txt`
- implement Flask API to store equations
- fetch sheet data via Google API
- save results to SQLAlchemy DB
- document setup in README

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_687fae7c9eb083318a1c550ce17b9f1c